### PR TITLE
Implement logic that is using defaultFixedTopLevelDomains like a fallback

### DIFF
--- a/src/mailcheck.js
+++ b/src/mailcheck.js
@@ -186,10 +186,8 @@ var Mailcheck = {
       switch (i) {
         case emailParts.secondLevelDomain:
           suggestionParts.secondLevelDomain = emailParts.secondLevelDomain;
-          break;
         case suggestionParts.secondLevelDomain:
           suggestionParts.topLevelDomain = fixedTopLevelDomains[i];
-          break;
         default:
           return false;
       }


### PR DESCRIPTION
In the event that the user entered gmail.de, roll back to the spare value of gmail.com